### PR TITLE
Keep SSH host keys

### DIFF
--- a/provisioning_templates/provision/keep_ssh_host_keys.erb
+++ b/provisioning_templates/provision/keep_ssh_host_keys.erb
@@ -1,0 +1,108 @@
+<%#
+name: LOL keep ssh host keys
+snippet: true
+model: ProvisioningTemplate
+%>
+
+# Nifty trick to restore keys without using a nochroot %post
+# Shamelessly cribbed from the Spacewalk project
+
+echo "Saving keys..." > /dev/ttyS0
+
+SEARCHDIR=/etc/ssh
+TEMPDIR=ssh
+PATTERN=ssh_host_
+
+export keys_found=no
+# /var could be a separate partition
+SHORTDIR=${SEARCHDIR#/var}
+if [ $SHORTDIR = $SEARCHDIR ]; then
+	SHORTDIR=''
+fi	
+insmod /lib/jbd.o
+insmod /lib/ext3.o
+
+mkdir -p /tmp/$TEMPDIR
+
+function findkeys
+{
+	for disk in $DISKS; do
+		name=$(basename $disk)
+		tmpdir=$(mktemp -d $name.XXXXXX)
+		mkdir -p /tmp/$tmpdir
+		mount $disk /tmp/$tmpdir
+		if [ $? -ne 0 ]; then # Skip to the next partition if the mount fails
+			rm -rf /tmp/$tmpdir                                                
+			continue                                                           
+		fi                                                                   
+		# Copy current host keys out to be reused
+		if [ -d /tmp/$tmpdir$SEARCHDIR -a $(ls /tmp/$tmpdir$SEARCHDIR/${PATTERN}* 2> /dev/null | wc -l) -gt 0 ]; then
+			cp -a /tmp/$tmpdir$SEARCHDIR/${PATTERN}* /tmp/$TEMPDIR
+			keys_found="yes"
+			umount /tmp/$tmpdir
+			rm -r /tmp/$tmpdir
+			break
+		elif [ -n "$SHORTDIR" ] && [ -d /tmp/$tmpdir$SHORTDIR ]; then
+			cp -a /tmp/$tmpdir$SHORTDIR/${PATTERN}* /tmp/$TEMPDIR
+			keys_found="yes"
+			umount /tmp/$tmpdir
+			rm -r /tmp/$tmpdir
+			break
+		fi
+		umount /tmp/$tmpdir
+		rm -r /tmp/$tmpdir
+	done
+}
+
+DISKS=$(awk '{if ($NF ~ "^[a-zA-Z].*[0-9]$" && $NF !~ "c[0-9]+d[0-9]+$" && $NF !~ "^loop.*") print "/dev/"$NF}'  /proc/partitions)
+# In the awk line above we want to make list of partitions, but not devices/controllers
+# cciss raid controllers have partitions like /dev/cciss/cNdMpL, where N,M,L - some digits, we want to make sure 'pL' is there
+# No need to scan loopback niether.
+# Try to find the keys on ordinary partitions
+
+findkeys
+
+# Try software RAID
+if [ "$keys_found" = "no" ]; then
+	if mdadm -As; then
+		DISKS=$(awk '/md/{print "/dev/"$1}' /proc/mdstat)
+		findkeys
+	fi
+fi
+
+
+# Try LVM if that didn't work
+if [ "$keys_found" = "no" ]; then
+	lvm lvmdiskscan
+	vgs=$(lvm vgs | tail -n +2 | awk '{ print $1 }')
+	for vg in $vgs; do
+		# Activate any VG we found
+		lvm vgchange -ay $vg
+	done
+
+	DISKS=$(lvm lvs | tail -n +2 | awk '{ print "/dev/" $2 "/" $1 }')
+	findkeys    
+
+	# And clean up..
+	for vg in $vgs; do
+		lvm vgchange -an $vg
+	done
+fi
+
+# Loop until the corresponding rpm is installed
+if [ "$keys_found" = "yes" ]; then
+    ps -ft pts/0
+    echo Current process is $$
+    set -x
+	while : ; do
+		sleep 10
+		if [ -d /mnt/sysimage$SEARCHDIR ] ; then
+			cp -af /tmp/$TEMPDIR/${PATTERN}* /mnt/sysimage$SEARCHDIR
+			if [ -e "/sbin/restorecon" ]; then
+				/sbin/restorecon -r /etc/ssh
+			fi
+			logger "keys copied to newly installed system"
+			break
+		fi
+	done < /dev/null > /tmp/keep_ssh_host_keys.txt 2>&1 &
+fi


### PR DESCRIPTION
This snippet should be triggered either through a custom pre-execution call, or embedded directly in the Kickstart default provisioning template.

If the latter, it might be a good idea to condition the inclusion based on a host parameter such as keep_ssh_host_keys

@lzap : https://community.theforeman.org/t/keep-ssh-host-keys-ex-spacewalk-users-primarily/15752